### PR TITLE
Support AST sharing across the detectives and module type detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/Readme.md
+++ b/Readme.md
@@ -4,11 +4,13 @@
 
 `npm install precinct`
 
-Uses the appropriate detective to find the dependencies of a file.
+Uses the appropriate detective to find the dependencies of a file or its AST.
 
 Supports: AMD, CommonJS, and ES6 modules.
 
 Also supports SASS dependencies via [detective-sass](https://github.com/mrjoelkemp/node-detective-sass).
+
+* Does not support a SASS AST
 
 ### Usage
 
@@ -17,6 +19,7 @@ var precinct = require('precinct');
 
 var content = fs.readFileSync('myFile.js', 'utf8');
 
+// Pass in a file's content or an AST
 var deps = precinct(content);
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-precinct",
   "dependencies": {
+    "acorn": "~0.10.0",
     "detective": "~4.0.0",
-    "detective-amd": "~2.2.2",
-    "detective-es6": "~1.0.2",
+    "detective-amd": "~2.3.0",
+    "detective-cjs": "~1.0.1",
+    "detective-es6": "~1.1.0",
     "detective-sass": "~1.0.1",
-    "module-definition": "~2.1.0"
+    "module-definition": "~2.2.0"
   },
   "devDependencies": {
     "jscs": "~1.7.3",

--- a/test/index.js
+++ b/test/index.js
@@ -3,8 +3,40 @@ var assert = require('assert');
 var fs = require('fs');
 
 describe('node-precinct', function() {
+  it('accepts an AST', function() {
+    var ast = {
+      type: 'Program',
+      body: [{
+        type: 'VariableDeclaration',
+        declarations: [{
+          type: 'VariableDeclarator',
+          id: {
+            type: 'Identifier',
+            name: 'a'
+          },
+          init: {
+            type: 'CallExpression',
+            callee: {
+              type: 'Identifier',
+              name: 'require'
+            },
+            arguments: [{
+              type: 'Literal',
+              value: './a',
+              raw: './a'
+            }]
+          }
+        }],
+        kind: 'var'
+      }]
+    };
+
+    var deps = precinct(ast);
+    assert(deps.length === 1);
+  });
+
   it('grabs dependencies of amd modules', function() {
-    var amd  = precinct(fs.readFileSync(__dirname + '/amd.js', 'utf8'));
+    var amd = precinct(fs.readFileSync(__dirname + '/amd.js', 'utf8'));
     assert(amd.indexOf('./a') !== -1);
     assert(amd.indexOf('./b') !== -1);
     assert(amd.length === 2);


### PR DESCRIPTION
Does an initial parse of the file to share the AST between module-definition and the chosen (js-centric) detective. This avoid double-parsing for a performance gain.
