### PR TITLE
Use the scss detective

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var detectiveCjs = require('detective-cjs');
 var detectiveAmd = require('detective-amd');
 var detectiveEs6 = require('detective-es6');
 var detectiveSass = require('detective-sass');
+var detectiveScss = require('detective-scss');
 var detectiveStylus = require('detective-stylus');
 
 var fs = require('fs');
@@ -77,6 +78,9 @@ function precinct(content, options) {
     case 'sass':
       theDetective = detectiveSass;
       break;
+    case 'scss':
+      theDetective = detectiveScss;
+      break;
     case 'stylus':
       theDetective = detectiveStylus;
       break;
@@ -125,14 +129,11 @@ precinct.paperwork = function(filename, options) {
   var ext = path.extname(filename);
   var type;
 
-  if (ext === '.scss' || ext === '.sass') {
-    type = 'sass';
+  if (ext === '.scss' || ext === '.sass' || ext === '.less') {
+    type = ext.replace('.', '');
 
   } else if (ext === '.styl') {
     type = 'stylus';
-
-  } else if (ext === '.less') {
-    type = 'less';
   }
 
   options.type = type;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "detective-amd": "^2.4.0",
     "detective-cjs": "^2.0.0",
     "detective-es6": "^1.1.6",
-    "detective-sass": "^1.2.0",
+    "detective-sass": "^1.2.2",
+    "detective-scss": "^1.0.0",
     "detective-stylus": "^1.0.0",
     "module-definition": "^2.2.4",
     "node-source-walk": "^3.2.0"

--- a/test/index.js
+++ b/test/index.js
@@ -27,8 +27,13 @@ describe('node-precinct', function() {
     assert.notDeepEqual(precinct.ast, ast);
   });
 
-  it('dangles off the parsed ast from a non-js file\'s detective that dangles its parsed ast', function() {
-    precinct(read('styles.scss'), 'sass');
+  it('dangles off the parsed ast from a scss detective', function() {
+    precinct(read('styles.scss'), 'scss');
+    assert.notDeepEqual(precinct.ast, {});
+  });
+
+  it('dangles off the parsed ast from a sass detective', function() {
+    precinct(read('styles.sass'), 'sass');
     assert.notDeepEqual(precinct.ast, {});
   });
 
@@ -69,9 +74,14 @@ describe('node-precinct', function() {
     assert(cjs.length === 0);
   });
 
-  it('grabs dependencies of sass files', function() {
-    var sass = precinct(read('styles.scss'), 'sass');
-    assert.deepEqual(sass, ['_foo', 'baz.scss']);
+  it('grabs dependencies of scss files', function() {
+    var scss = precinct(read('styles.scss'), 'scss');
+    assert.deepEqual(scss, ['_foo', 'baz.scss']);
+  });
+
+  it('grabs dependencies of scss files', function() {
+    var sass = precinct(read('styles.sass'), 'sass');
+    assert.deepEqual(sass, ['_foo']);
   });
 
   it('grabs dependencies of stylus files', function() {

--- a/test/styles.sass
+++ b/test/styles.sass
@@ -1,0 +1,1 @@
+@import _foo


### PR DESCRIPTION
Needed to avoid the configuration mess with the sass parser requiring us to differentiate between scss and sass syntax. 

Refs https://github.com/dependents/node-detective-sass/pull/10