### PR TITLE
Upgrade precinct to use detective-sass 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "detective-amd": "^2.4.0",
     "detective-cjs": "^2.0.0",
     "detective-es6": "^1.1.6",
-    "detective-sass": "^1.2.2",
+    "detective-sass": "^2.0.0",
     "detective-scss": "^1.0.0",
     "detective-stylus": "^1.0.0",
     "module-definition": "^2.2.4",


### PR DESCRIPTION
This is cleanup since we're not using detective-scss for scss files.

The last release of detective-sass 1 had config to choose the syntax
which we no longer need.

Refs https://github.com/dependents/node-detective-sass/pull/11