### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,19 +33,19 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-precinct",
   "dependencies": {
-    "commander": "^2.11.0",
-    "debug": "^3.0.1",
+    "commander": "^2.17.0",
+    "debug": "^3.1.0",
     "detective-amd": "^2.4.0",
-    "detective-cjs": "^2.0.0",
-    "detective-es6": "^1.2.0",
+    "detective-cjs": "^3.0.0",
+    "detective-es6": "^2.0.0",
     "detective-less": "^1.0.1",
     "detective-postcss": "^2.1.0",
-    "detective-sass": "^2.0.0",
-    "detective-scss": "^1.0.0",
+    "detective-sass": "^2.0.1",
+    "detective-scss": "^2.0.0",
     "detective-stylus": "^1.0.0",
     "detective-typescript": "^3.0.0",
-    "module-definition": "^2.2.4",
-    "node-source-walk": "^3.3.0"
+    "module-definition": "^3.0.0",
+    "node-source-walk": "^4.0.0"
   },
   "devDependencies": {
     "jscs": "~3.0.7",


### PR DESCRIPTION
* Most detectives now use an upgraded babylon version to 7 which required a new major version throughout.

Going to release a major version in case shit breaks hard for folks with the upgraded babel version.