### PR TITLE
Add support for `.tsx` file extension.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function precinct(content, options) {
       theDetective = detectiveTypeScript;
       break;
     case 'tsx':
-      theDetective = detectiveTypeScript;
+      theDetective = detectiveTypeScript.tsx;
       break;
   }
 
@@ -151,14 +151,6 @@ precinct.paperwork = function(filename, options) {
   }
 
   options.type = type;
-  
-  if (type === 'tsx') {
-    options.tsx = assign({
-      ecmaFeatures: assign({
-        jsx: true
-      }, (options.tsx && options.tsx.ecmaFeatures) || {});
-    }, options.tsx || {});
-  }
 
   var deps = precinct(content, options);
 

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ precinct.paperwork = function(filename, options) {
   var ext = path.extname(filename);
   var type;
 
-  if (ext === '.css' || ext === '.scss' || ext === '.sass' || ext === '.less' || ext === '.ts') {
+  if (ext === '.css' || ext === '.scss' || ext === '.sass' || ext === '.less' || ext === '.ts' || ext === '.tsx') {
     type = ext.replace('.', '');
 
   } else if (ext === '.styl') {

--- a/index.js
+++ b/index.js
@@ -96,6 +96,9 @@ function precinct(content, options) {
     case 'ts':
       theDetective = detectiveTypeScript;
       break;
+    case 'tsx':
+      theDetective = detectiveTypeScript;
+      break;
   }
 
   if (theDetective) {

--- a/index.js
+++ b/index.js
@@ -146,12 +146,19 @@ precinct.paperwork = function(filename, options) {
 
   if (ext === '.css' || ext === '.scss' || ext === '.sass' || ext === '.less' || ext === '.ts' || ext === '.tsx') {
     type = ext.replace('.', '');
-
   } else if (ext === '.styl') {
     type = 'stylus';
   }
 
   options.type = type;
+  
+  if (type === 'tsx') {
+    options.tsx = assign({
+      ecmaFeatures: assign({
+        jsx: true
+      }, (options.tsx && options.tsx.ecmaFeatures) || {});
+    }, options.tsx || {});
+  }
 
   var deps = precinct(content, options);
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "detective-sass": "^3.0.0",
     "detective-scss": "^2.0.0",
     "detective-stylus": "^1.0.0",
-    "detective-typescript": "^4.0.0",
+    "detective-typescript": "^4.1.1",
     "module-definition": "^3.0.0",
     "node-source-walk": "^4.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,12 @@ describe('node-precinct', function() {
     var result = precinct(read('typescriptWithError.ts'));
     assert(result.length === 0);
   });
+  
+  it('grabs dependencies of typescript tsx files', function() {
+    var result = precinct(read('typescript-jsx.tsx'), 'tsx');
+    var expected = ['foo'];
+    assert.deepEqual(result, expected);
+  });
 
   it('supports the object form of type configuration', function() {
     var result = precinct(read('styles.styl'), {type: 'stylus'});

--- a/test/typescript-jsx.tsx
+++ b/test/typescript-jsx.tsx
@@ -1,0 +1,3 @@
+import Foo from 'foo';
+
+export const theFoo = <Foo/>;


### PR DESCRIPTION
This works together with https://github.com/pahen/detective-typescript/pull/11 to pass the appropriate `typescript-eslint-parser` options for parsing JSX in TypeScript files with the `.tsx` extension.