### PR TITLE
Support passing alternative fs in options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,9 @@ var deps2 = paperwork('styles.scss');
 Supported options:
 
 * `includeCore`: (default: true) set to `false` to exclude core Node dependencies from the list of dependencies.
+* `fs`: (default: undefined) set to an alternative `fs` implementation that will be used to read the file path.
 * You may also pass detective-specific configuration like you would to `precinct(content, options)`.
+* 
 
 #### CLI
 

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ function assign(o1, o2) {
  * @param {String} filename
  * @param {Object} [options]
  * @param {Boolean} [options.includeCore=true] - Whether or not to include core modules in the dependency list
+ * @param {Object} [options.fs=undefined] - An alternative fs implementation to use for reading the file path.
  * @return {String[]}
  */
 precinct.paperwork = function(filename, options) {
@@ -137,7 +138,8 @@ precinct.paperwork = function(filename, options) {
     includeCore: true
   }, options || {});
 
-  var content = fs.readFileSync(filename, 'utf8');
+  var fileSystem = options.fs || fs;
+  var content =  fileSystem.readFileSync(filename, 'utf8');
   var ext = path.extname(filename);
   var type;
 

--- a/test/index.js
+++ b/test/index.js
@@ -152,6 +152,22 @@ describe('node-precinct', function() {
   });
 
   describe('paperwork', function() {
+    it('uses fs from options if provided', function() {
+      var fsMock = {
+        readFileSync: function(path, encoding) {
+          assert.equal(path, '/foo.js');
+          return 'var assert = require("assert");';
+        }
+      };
+
+      var options = {
+        fs: fsMock
+      };
+      var results = precinct.paperwork('/foo.js', options);
+      assert.equal(results.length, 1);
+      assert.equal(results[0], 'assert');
+    });
+
     it('returns the dependencies for the given filepath', function() {
       assert.ok(precinct.paperwork(__dirname + '/es6.js').length);
       assert.ok(precinct.paperwork(__dirname + '/styles.scss').length);


### PR DESCRIPTION
Closes #51

Allows an `fs` implementation to be passed in paperwork options, for the purpose of providing sources for analysis from alternative locations other than just the physical file system (like in memory, or unionfs etc).