### PR TITLE
Bump detective-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -620,13 +620,13 @@
       "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0="
     },
     "detective-typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-4.1.2.tgz",
-      "integrity": "sha512-jeQMIN/0hjMdMpFGoo9y+ibo+dTb1Vbg6z/peHoRMR69jqH691kgz1gT5XM5UfkDD/Ru0save1bSJBmUr2yjvQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-5.0.0.tgz",
+      "integrity": "sha512-w+UpXVC5jE1mI/rVbA9OndSmYexbCmtmKDExfib/j3qW+fYYoYzs1I9W+E5pmjXKBNBgkEMtdnlcQMbN9U5fpg==",
       "requires": {
-        "node-source-walk": "^4.0.0",
-        "typescript": "^3.0.3",
-        "typescript-eslint-parser": "^18.0.0"
+        "node-source-walk": "4.2.0",
+        "typescript": "3.1.1",
+        "typescript-eslint-parser": "21.0.2"
       }
     },
     "diff": {
@@ -849,8 +849,7 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "3.5.4",
@@ -880,7 +879,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
       }
@@ -1489,7 +1487,7 @@
     },
     "minimist": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
       "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
     },
     "mkdirp": {
@@ -2211,14 +2209,35 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ=="
     },
     "typescript-eslint-parser": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-18.0.0.tgz",
-      "integrity": "sha512-Pn/A/Cw9ysiXSX5U1xjBmPQlxtWGV2o7jDNiH/u7KgBO2yC/y37wNFl2ogSrGZBQFuglLzGq0Xl0Bt31Jv44oA==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
+      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
+      "requires": {
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "typescript-estree": "5.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "typescript-estree": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
+      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
       "requires": {
         "lodash.unescape": "4.0.1",
         "semver": "5.5.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "detective-sass": "^3.0.0",
     "detective-scss": "^2.0.0",
     "detective-stylus": "^1.0.0",
-    "detective-typescript": "^4.1.2",
+    "detective-typescript": "^5.0.0",
     "module-definition": "^3.1.0",
     "node-source-walk": "^4.2.0"
   },


### PR DESCRIPTION
A new major version of `detective-typescript` was released to fix the following error when running in the terminal:
```
  TypeScript
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: ~3.0.1

YOUR TYPESCRIPT VERSION: 3.2.2

Please only submit bug reports when using the officially supported version.
```

See https://github.com/pahen/detective-typescript/commit/8e62618c0503f7faa3e229c4ae853d8ac289c6a2