### PR TITLE
Add --type CLI argument

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,7 @@ program
   .version(require('../package.json').version)
   .usage('[options] <filename>')
   .option('--es6-mixedImports')
+  .option('-t, --type <type>', 'The type of content being passed in. Useful if you want to use a non-js detective')
   .parse(process.argv);
 
 var content = fs.readFileSync(program.args[0], 'utf8');
@@ -20,6 +21,10 @@ var options = {
 
 if (program['es6MixedImports']) {
   options.es6.mixedImports = true;
+}
+
+if (program.type) {
+  options.type = program.type;
 }
 
 console.log(precinct(content, options));


### PR DESCRIPTION
I've been doing some debugging around working out why some imports not appearing using typescript recently and CLI options  for the various layers have saved a bit of time