### PR TITLE
Detect Node.js .cjs files as commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,10 @@ precinct.paperwork = function(filename, options = {}) {
     debug('paperwork: converting .styl into the stylus type');
     type = 'stylus';
   }
+  else if (ext === '.cjs') {
+    debug('paperwork: converting .cjs into the commonjs type');
+    type = 'commonjs';
+  }
   // We need to sniff the JS module to find its type, not by extension
   // Other possible types pass through normally
   else if (ext !== '.js' && ext !== '.jsx') {

--- a/index.js
+++ b/index.js
@@ -142,8 +142,7 @@ precinct.paperwork = function(filename, options = {}) {
   if (ext === '.styl') {
     debug('paperwork: converting .styl into the stylus type');
     type = 'stylus';
-  }
-  else if (ext === '.cjs') {
+  } else if (ext === '.cjs') {
     debug('paperwork: converting .cjs into the commonjs type');
     type = 'commonjs';
   }


### PR DESCRIPTION
It seems that precinct doesn't recognize [.cjs files of Node.js 12+](https://nodejs.org/api/packages.html#packages_determining_module_system).

I have a `cjs.11ty.cjs` file that looks like this:
```js
const HEAD = require('./_includes/head.11ty.cjs');

module.exports = `<html>${HEAD}<body> ... `;
```

Currently precinct (called by `dependency-tree`) does not recognize the `.cjs` extension and will not walk the dependency tree (`head.11ty.cjs` is not listed in the result):

![11ty-precinct1](https://user-images.githubusercontent.com/2089432/108695981-9af78400-7509-11eb-8633-5803674724cb.png)

My straightforward fix is to handle this the same way `.styl` files are: `.cjs` extensions simply default to `commonjs` type, as these files are [guaranteed](https://nodejs.org/api/packages.html#packages_determining_module_system) to be treated as CommonJS modules by Node.js.

With this fix, the `commonjs` type is correctly recognized, and the dependency tree is walked:
![11ty-precinct2-fixed](https://user-images.githubusercontent.com/2089432/108696644-8071da80-750a-11eb-8473-faf13eac96b2.png)
