### PR TITLE
mocha: tighten options

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,7 @@
+{
+  "check-leaks": true,
+  "throw-deprecation": true,
+  "trace-deprecation": true,
+  "trace-warnings": true,
+  "use_strict": true
+}


### PR DESCRIPTION
This should throw the errors from https://github.com/dependents/node-source-walk/pull/29.

Should be merged when the upstream issues are fixed and there's a new upstream version :)