### PR TITLE
fix: teach precinct about node:-prefixed modules introduced in Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
 
     steps:
       - name: Clone repository

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ precinct.paperwork = (filename, options = {}) => {
         return false
       }
 
-      if (["test"].includes(dep)) { // some builtins can only be access via node: prefix
+      if (["test"].includes(dep)) { // some builtins can only be accessed via node: prefix
         return true
       }
 

--- a/index.js
+++ b/index.js
@@ -161,7 +161,18 @@ precinct.paperwork = (filename, options = {}) => {
   const deps = precinct(content, options);
 
   if (!options.includeCore) {
-    return deps.filter((dep) => dep.startsWith('node:') ? false : !natives[dep]);
+    return deps.filter((dep) => {
+      if (dep.startsWith('node:')) {
+        return false
+      }
+
+      if (["test"].includes(dep)) { // some builtins can only be access via node: prefix
+        return true
+      }
+
+      const isInNatives = Boolean(natives[dep]);
+      return !isInNatives;
+    });
   }
 
   debug('paperwork: got these results\n', deps);

--- a/test/fixtures/requiretest.js
+++ b/test/fixtures/requiretest.js
@@ -1,0 +1,1 @@
+require("test");

--- a/test/index.js
+++ b/test/index.js
@@ -348,6 +348,13 @@ describe('node-precinct', () => {
         assert.ok(!deps.includes('node:nonexistant'));
         assert.deepEqual(deps, ['streams']);
       });
+
+      it("understands quirks around somem modules only being addressable via node: prefix", () => {
+        const deps = precinct.paperwork(path.join(__dirname, 'fixtures', 'requiretest.js'), {
+          includeCore: false
+        });
+        assert.deepEqual(deps, ['test']);
+      })
     });
 
     describe('that uses dynamic imports', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -349,7 +349,7 @@ describe('node-precinct', () => {
         assert.deepEqual(deps, ['streams']);
       });
 
-      it("understands quirks around somem modules only being addressable via node: prefix", () => {
+      it("understands quirks around some modules only being addressable via node: prefix", () => {
         const deps = precinct.paperwork(path.join(__dirname, 'fixtures', 'requiretest.js'), {
           includeCore: false
         });


### PR DESCRIPTION
Node v18 was released a couple days ago, and it ships a new `node:test` builtin. Interestingly (and different from existing builtins), it can *only* be imported using the `node:` prefix:

![Screenshot 2022-04-21 at 14 58 55](https://user-images.githubusercontent.com/14912729/164463202-b7b88762-6900-452c-98e3-2eb2b4b84e47.png)

Thus, `precinct.paperwork` should not exclude `require("test")` when `includeCore: true` is set.