### PR TITLE
Update detective-postcss to v6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "detective-cjs": "^4.0.0",
         "detective-es6": "^3.0.0",
         "detective-less": "^1.0.2",
-        "detective-postcss": "^6.0.1",
+        "detective-postcss": "^6.1.0",
         "detective-sass": "^4.0.1",
         "detective-scss": "^3.0.0",
         "detective-stylus": "^2.0.0",
@@ -765,16 +765,16 @@
       }
     },
     "node_modules/detective-postcss": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.0.1.tgz",
-      "integrity": "sha512-KJu6te+ah3E07uX0ihVUd7buT2H3nDg8ycprsv1MpN++a0057jiMkmDSqkgbztqnUbhKsSkeWwJ6L2GmnbIQsg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.0.tgz",
+      "integrity": "sha512-ZFZnEmUrL2XHAC0j/4D1fdwZbo/anAcK84soJh7qc7xfx2Kc8gFO5Bk5I9jU7NLC/OAF1Yho1GLxEDnmQnRH2A==",
       "dependencies": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.12",
         "postcss-values-parser": "^6.0.2"
       },
       "engines": {
-        "node": "12.x || 14.x || 16.x"
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/detective-sass": {
@@ -3550,12 +3550,12 @@
       }
     },
     "detective-postcss": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.0.1.tgz",
-      "integrity": "sha512-KJu6te+ah3E07uX0ihVUd7buT2H3nDg8ycprsv1MpN++a0057jiMkmDSqkgbztqnUbhKsSkeWwJ6L2GmnbIQsg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.0.tgz",
+      "integrity": "sha512-ZFZnEmUrL2XHAC0j/4D1fdwZbo/anAcK84soJh7qc7xfx2Kc8gFO5Bk5I9jU7NLC/OAF1Yho1GLxEDnmQnRH2A==",
       "requires": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.12",
         "postcss-values-parser": "^6.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "detective-cjs": "^4.0.0",
     "detective-es6": "^3.0.0",
     "detective-less": "^1.0.2",
-    "detective-postcss": "^6.0.1",
+    "detective-postcss": "^6.1.0",
     "detective-sass": "^4.0.1",
     "detective-scss": "^3.0.0",
     "detective-stylus": "^2.0.0",


### PR DESCRIPTION
We are encountering this error with node v18 [in CI ](https://github.com/netlify/cli/runs/6506637762?check_suite_focus=true#step:6:425) from a precinct v9.0.1 dependency: `error detective-postcss@6.0.1: The engine "node" is incompatible with this module. Expected version "12.x || 14.x || 16.x". Got "18.2.0"`. This would get fixed by upgrading to v6.1.0 of [detective-postcss](https://github.com/dependents/node-detective-postcss) thanks to this [commit](https://github.com/dependents/node-detective-postcss/commit/ad2befa8c2e07e31b0acbd8e7c9b6a9fd89f8268) that's part of it.