### PR TITLE
Add support for vue single file components

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const detectiveSass = require('detective-sass');
 const detectiveScss = require('detective-scss');
 const detectiveStylus = require('detective-stylus');
 const detectiveTypeScript = require('detective-typescript');
+const detectiveVue = require('detective-vue2');
 
 const debug = debuglog('precinct');
 // eslint-disable-next-line n/no-deprecated-api
@@ -181,6 +182,10 @@ function getDetective(type, options) {
 
     case 'tsx': {
       return detectiveTypeScript.tsx;
+    }
+
+    case 'vue': {
+      return detectiveVue;
     }
 
     default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "detective-scss": "^5.0.0",
         "detective-stylus": "^5.0.0",
         "detective-typescript": "^13.0.0",
+        "detective-vue2": "^2.0.0",
         "module-definition": "^6.0.0",
         "node-source-walk": "^7.0.0",
         "postcss": "^8.4.38",
@@ -374,8 +375,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -746,6 +746,57 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
+      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
+      "dependencies": {
+        "@babel/parser": "^7.23.9",
+        "@vue/shared": "3.4.21",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
+      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
+      "dependencies": {
+        "@vue/compiler-core": "3.4.21",
+        "@vue/shared": "3.4.21"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
+      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
+      "dependencies": {
+        "@babel/parser": "^7.23.9",
+        "@vue/compiler-core": "3.4.21",
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/compiler-ssr": "3.4.21",
+        "@vue/shared": "3.4.21",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.7",
+        "postcss": "^8.4.35",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
+      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/shared": "3.4.21"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
+      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -1865,6 +1916,25 @@
         "typescript": "^5.4.4"
       }
     },
+    "node_modules/detective-vue2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.0.0.tgz",
+      "integrity": "sha512-ekM2hRKr2ra8QkLiuHADBx/wA05EpMCQXbq57Ujfc4kD5VtnANIiE2p/Z5Ic2xbVSeAyQbiQfjvvmCPZrW5Yrg==",
+      "dependencies": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "detective-es6": "^5.0.0",
+        "detective-sass": "^6.0.0",
+        "detective-scss": "^5.0.0",
+        "detective-stylus": "^5.0.0",
+        "detective-typescript": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4"
+      }
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1933,6 +2003,17 @@
       },
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -2904,6 +2985,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4511,6 +4597,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
+      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "detective-scss": "^5.0.0",
     "detective-stylus": "^5.0.0",
     "detective-typescript": "^13.0.0",
+    "detective-vue2": "^2.0.0",
     "module-definition": "^6.0.0",
     "node-source-walk": "^7.0.0",
     "postcss": "^8.4.38",

--- a/test/fixtures/js.vue
+++ b/test/fixtures/js.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>Hello</div>
+</template>
+<script>
+  import foo from './typescript';
+</script>
+<style lang="sass">
+  @import 'styles.scss'
+</style>

--- a/test/fixtures/ts.vue
+++ b/test/fixtures/ts.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>Hello</div>
+</template>
+<script lang="ts">
+import foo from './typescript';
+</script>
+<style lang="scss">
+@import 'styles.scss';
+</style>

--- a/test/test.js
+++ b/test/test.js
@@ -319,6 +319,24 @@ describe('node-precinct', () => {
     });
   });
 
+  describe('when given vue file', () => {
+    it('typescript - scss grabs script and style dependencies', () => {
+      const vueFile = precinct.paperwork(path.join(__dirname, 'fixtures', 'ts.vue'));
+
+      assert.equal(vueFile[0], './typescript');
+      assert.equal(vueFile[1], 'styles.scss');
+      assert.equal(vueFile.length, 2);
+    });
+
+    it('javascript - sass grabs script and style dependencies', () => {
+      const vueFile = precinct.paperwork(path.join(__dirname, 'fixtures', 'js.vue'));
+
+      assert.equal(vueFile[0], './typescript');
+      assert.equal(vueFile[1], 'styles.scss');
+      assert.equal(vueFile.length, 2);
+    });
+  });
+
   describe('when lazy exported dependencies in CJS', () => {
     it('grabs those lazy dependencies', async() => {
       const fixture = await read('cjsExportLazy.js');


### PR DESCRIPTION
I realized vue sfc compiler v3 can also parse vue2 files which is enough to pull out dependencies from them, so I pinned the vue3 compiler as a dependency and that should fix the previous issue. I also merged latest changes to the PR